### PR TITLE
adds dependency to timriffe fork of ungroup (can be changes to mpasca…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fertestr
 Title: Package for Fertility and Parity Estimation
-Version: 0.0.0.9000
+Version: 0.0.1
 Authors@R: c(
     person(given = "José H",
            family = "Monteiro da Silva",
@@ -27,7 +27,8 @@ Imports:
     DemoToolsData (>= 0.0.0.9000)
 Remotes: 
     mpascariu/MortalityEstimate,
-    timriffe/DemoToolsData
+    timriffe/DemoToolsData,
+    timriffe/ungroup
 Suggests: 
     countrycode,
     sf,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fertestr
 Title: Package for Fertility and Parity Estimation
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: c(
     person(given = "José H",
            family = "Monteiro da Silva",
@@ -28,7 +28,7 @@ Imports:
 Remotes: 
     mpascariu/MortalityEstimate,
     timriffe/DemoToolsData,
-    timriffe/ungroup
+    mpascariu/ungroup
 Suggests: 
     countrycode,
     sf,


### PR DESCRIPTION
Hi Jose! This PR merely changes the reference for `ungroup` to my github fork rather than the CRAN version. The CRAN version is down due to problems in the dependency chain. I've revived the chain temporarily, which should now make `MortalitySmooth`, `ungroup`, `fertestr`, and `DemoTools` installable again. If @mpascariu merges the PR I made to `ungroup` then the ref should change back there, in case he makes more changes. And once he puts it back on CRAN, we can remove `ungroup` from the remotes list. Happy 2021!