### PR TITLE
adds graceful stop if location not available

### DIFF
--- a/R/reverse_survival_aux.R
+++ b/R/reverse_survival_aux.R
@@ -298,6 +298,10 @@ FetchLifeTableWpp2019 <- function( locations = NULL, year, sex = 'both'){
     if( tolower( sex ) == 'male' | tolower( sex ) == 'both' ){
 
       mxM <- load_named_data('mxM', "wpp2019")
+
+      # TR: enforce we have the location
+      stopifnot(location_code %in% mxM$country_code)
+
       mx_inf <- mxM[ mxM$country_code %in% location_code,
                      c( paste0( year_inf - 5, '-', year_inf ) ) ]
 
@@ -331,6 +335,10 @@ FetchLifeTableWpp2019 <- function( locations = NULL, year, sex = 'both'){
     if( tolower( sex ) == 'female' | tolower( sex ) == 'both' ){
 
       mxF <- load_named_data('mxF', "wpp2019")
+
+      # TR: enforce we have the location
+      stopifnot(location_code %in% mxM$country_code)
+
       mx_inf <- mxF[ mxF$country_code %in% location_code,
                      c( paste0( year_inf - 5, '-', year_inf ) ) ]
 


### PR DESCRIPTION
This just adds said stop to `FetchLifeTableWpp2019()`.

Before making this change, this line gives an error message from `MortalityLaws` re `m[1] < 0`, but the real issue is that `m` is a zero length vector.
`FetchLifeTableWpp2019("American Samoa", 1991, "male")`

If merged, this PR would instead give the error:
`"location_code %in% mxM$country_code is not TRUE"`

Which of course could be more verbose, but at least it spots the correct problem. Possibly other `Fetch*` functions could use the same check. But in this case it might be better to have a helper function that just does this simple check.